### PR TITLE
add conditional check for api.onStory

### DIFF
--- a/src/register.js
+++ b/src/register.js
@@ -34,9 +34,11 @@ export class FigmaPanel extends React.Component {
     const { channel, api } = this.props
     channel.on(EVENT_ID, this.onAddFigma)
 
-    this.stopListeningOnStory = api.onStory(() => {
-      this.onAddFigma({ ...FigmaPanel.initialState })
-    })
+    if (api.onStory && typeof api.onStory === 'function') {
+      this.stopListeningOnStory = api.onStory(() => {
+        this.onAddFigma({ ...FigmaPanel.initialState })
+      })
+    }
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Using React Native, this method does not appear to exist in the `api` prop. Removing the call allows the `Figma` tab to appear